### PR TITLE
Add Default Model Configuration for LLM Providers

### DIFF
--- a/openrelik_ai_common/providers/config.py
+++ b/openrelik_ai_common/providers/config.py
@@ -15,8 +15,8 @@
 import os
 
 PROVIDER_CONFIG = {
-    "ollama": ["OLLAMA_SERVER_URL"],
-    "vertexai": ["VERTEXAI_PROJECT_ID"],
+    "ollama": ["OLLAMA_SERVER_URL", "OLLAMA_DEFAULT_MODEL"],
+    "vertexai": ["VERTEXAI_PROJECT_ID", "VERTEXAI_DEFAULT_MODEL"],
 }
 
 

--- a/openrelik_ai_common/providers/interface.py
+++ b/openrelik_ai_common/providers/interface.py
@@ -30,7 +30,7 @@ class LLMProvider:
 
     def __init__(
         self,
-        model_name: str,
+        model_name: str = None,
         temperature: float = DEFAULT_TEMPERATURE,
         top_p: float = DEFAULT_TOP_P,
         top_k: int = DEFAULT_TOP_K,
@@ -64,8 +64,29 @@ class LLMProvider:
             raise Exception(f"{self.NAME} config not found")
         config.update(config_from_environment)
 
+        if not model_name:
+            config["model"] = config.get("default_model")
+
         # Expose the config as an attribute.
         self.config = config
+
+    def to_dict(self):
+        """Convert the LLM provider to a dictionary.
+
+        Returns:
+            A dictionary representation of the LLM provider.
+        """
+        return {
+            "name": self.NAME,
+            "display_name": self.DISPLAY_NAME,
+            "config": {
+                "model": self.config.get("model"),
+                "temperature": self.config.get("temperature"),
+                "top_p": self.config.get("top_p"),
+                "top_k": self.config.get("top_k"),
+                "max_output_tokens": self.config.get("max_output_tokens"),
+            },
+        }
 
     def count_tokens(self, prompt: str):
         """

--- a/openrelik_ai_common/providers/ollama.py
+++ b/openrelik_ai_common/providers/ollama.py
@@ -19,7 +19,7 @@ from ollama import Client
 
 
 class Ollama(interface.LLMProvider):
-    """A LLM provider for the ollama server."""
+    """A LLM provider for the Ollama server."""
 
     NAME = "ollama"
     DISPLAY_NAME = "Ollama"
@@ -38,6 +38,7 @@ class Ollama(interface.LLMProvider):
         Returns:
             The number of tokens in the prompt.
         """
+        # Rough estimate: ~4chars UTF8, 1bytes per char.
         return len(prompt) / 4
 
     def generate(self, prompt: str) -> str:


### PR DESCRIPTION
### Summary:
This change introduces default model configuration for LLM providers, allowing users to specify a default model for each provider and use it without explicitly providing the model name during initialization.  This simplifies the LLM interaction and provides a more streamlined user experience.  A `to_dict` method was also added to the `LLMProvider` interface to facilitate serialization of the provider configuration.

### Technical Details:

*   **Default Model Configuration:** Added `OLLAMA_DEFAULT_MODEL` and `VERTEXAI_DEFAULT_MODEL` to the `PROVIDER_CONFIG` in `openrelik_ai_common/providers/config.py`. This allows users to set a default model for each provider via environment variables.
*   **LLM Provider Initialization:** Modified the `__init__` method of the `LLMProvider` class in `openrelik_ai_common/providers/interface.py` to accept an optional `model_name` argument. If `model_name` is not provided, the provider will use the default model specified in the configuration.
*   **Configuration Serialization:**  Added a `to_dict` method to the `LLMProvider` class in `openrelik_ai_common/providers/interface.py`.  This method returns a dictionary representation of the LLM provider, including its name, display name, and configuration details (model, temperature, top_p, top_k, max_output_tokens). This allows for easy serialization and sharing of the provider's configuration.
*   **Ollama Documentation Update:** Clarified the docstring for the `Ollama` class in `openrelik_ai_common/providers/ollama.py` to accurately reflect its function as an Ollama server provider.  Added a comment explaining the token counting estimation logic.